### PR TITLE
limit alphamask to 250 in CustomGear and in AlphaMask Unity script

### DIFF
--- a/XLGearModifier.Gear/Assets/Assembly/ScriptableObjects/XLGMGearAlphaMaskConfig.cs
+++ b/XLGearModifier.Gear/Assets/Assembly/ScriptableObjects/XLGMGearAlphaMaskConfig.cs
@@ -9,7 +9,7 @@ namespace XLGearModifier.Unity.ScriptableObjects
 	public class XLGMGearAlphaMaskConfig : ScriptableObject
 	{
 		public AlphaMaskLocation MaskLocation;
-		[Range(0.0f, 255f)]
+		[Range(0.0f, 250f)]
 		public int Threshold;
 
 		public Texture2D AlphaMask;

--- a/XLGearModifier/CustomGear.cs
+++ b/XLGearModifier/CustomGear.cs
@@ -574,6 +574,8 @@ namespace XLGearModifier
 			{
 				if (mask == null) continue;
 
+				if (mask.Threshold > 250) mask.Threshold = 250;
+
 				var existing = template.alphaMasks.FirstOrDefault(x => (int)x.MaskLocation == (int)mask.MaskLocation);
 				if (existing == null)
 				{


### PR DESCRIPTION
https://github.com/MCBTay/XLGearModifier/issues/44

This will limit alphamask threshold to 250 in the alphamask unity script and in the CustomGear.cs file.  
- Tested with an item set to 255 alpha threshold before and after evaluation. 

Reason to have changes in both places:
- Tested Unity element for Alphamask and while the change does limit the slider to 250, an element with 255 alphamask that existed prior can still be applied.  
- Also old items with 255 mask exist since the leak. 
