### PR TITLE
Sort Meshes/Textures By Name Ascending

### DIFF
--- a/XLGearModifier/AssetBundleHelper.cs
+++ b/XLGearModifier/AssetBundleHelper.cs
@@ -192,13 +192,13 @@ namespace XLGearModifier
                         switch (metadata)
                         {
                             case XLGMClothingGearMetadata clothingMetadata:
-                                customGearBase = new CustomClothingGear(clothingMetadata, asset);
+                                customGearBase = new ClothingGear(clothingMetadata, asset);
                                 break;
                             case XLGMSkaterMetadata skaterMetadata:
-                                customGearBase = new CustomSkater(skaterMetadata, asset);
+                                customGearBase = new Skater(skaterMetadata, asset);
                                 break;
                             case XLGMBoardGearMetadata boardMetadata:
-                                customGearBase = new CustomBoardGear(boardMetadata, asset);
+                                customGearBase = new BoardGear(boardMetadata, asset);
                                 break;
                         }
                         if (customGearBase == null) continue;
@@ -209,10 +209,10 @@ namespace XLGearModifier
 
                         switch (customGearBase)
                         {
-                            case CustomClothingGear clothingGear:
+                            case ClothingGear clothingGear:
                                 GearManager.Instance.AddClothingMesh(clothingGear.ClothingMetadata, clothingGear, asset);
                                 break;
-                            case CustomBoardGear boardGear:
+                            case BoardGear boardGear:
                                 GearManager.Instance.AddBoardMesh(boardGear.BoardMetadata, boardGear, asset);
                                 break;
                         }

--- a/XLGearModifier/CustomGear/BoardGear.cs
+++ b/XLGearModifier/CustomGear/BoardGear.cs
@@ -11,16 +11,16 @@ using XLMenuMod.Utilities.Gear;
 
 namespace XLGearModifier.CustomGear
 {
-    public class CustomBoardGear : CustomGearBase
+    public class BoardGear : CustomGearBase
     {
         public XLGMBoardGearMetadata BoardMetadata => Metadata as XLGMBoardGearMetadata;
 
-        public CustomBoardGear(XLGMBoardGearMetadata metadata, GameObject prefab) 
+        public BoardGear(XLGMBoardGearMetadata metadata, GameObject prefab) 
             : base(metadata, prefab)
         {
         }
 
-        public CustomBoardGear(CustomGearBase customGearBase, CustomBoardGearInfo gearInfo)
+        public BoardGear(CustomGearBase customGearBase, CustomBoardGearInfo gearInfo)
             : base(customGearBase, gearInfo)
         {
 
@@ -102,19 +102,19 @@ namespace XLGearModifier.CustomGear
 
             switch (skaterIndex)
             {
-                case (int)Skater.EvanSmith:
+                case (int)XLMenuMod.Skater.EvanSmith:
                     Enum.TryParse(category, out EvanSmithGearCategory esCategory);
                     categoryIndex = (int)esCategory;
                     break;
-                case (int)Skater.TomAsta:
+                case (int)XLMenuMod.Skater.TomAsta:
                     Enum.TryParse(category, out TomAstaGearCategory taCategory);
                     categoryIndex = (int)taCategory;
                     break;
-                case (int)Skater.BrandonWestgate:
+                case (int)XLMenuMod.Skater.BrandonWestgate:
                     Enum.TryParse(category, out BrandonWestgateGearCategory bwCategory);
                     categoryIndex = (int)bwCategory;
                     break;
-                case (int)Skater.TiagoLemos:
+                case (int)XLMenuMod.Skater.TiagoLemos:
                     Enum.TryParse(category, out TiagoLemosGearCategory tlCategory);
                     categoryIndex = (int)tlCategory;
                     break;

--- a/XLGearModifier/CustomGear/ClothingGear.cs
+++ b/XLGearModifier/CustomGear/ClothingGear.cs
@@ -14,15 +14,15 @@ using ClothingGearCategory = SkaterXL.Gear.ClothingGearCategory;
 
 namespace XLGearModifier.CustomGear
 {
-    public class CustomClothingGear : CustomGearBase
+    public class ClothingGear : CustomGearBase
     {
         public XLGMClothingGearMetadata ClothingMetadata => Metadata as XLGMClothingGearMetadata;
 
-        public CustomClothingGear(XLGMClothingGearMetadata metadata, GameObject prefab) : base(metadata, prefab)
+        public ClothingGear(XLGMClothingGearMetadata metadata, GameObject prefab) : base(metadata, prefab)
         {
         }
 
-        public CustomClothingGear(CustomGearBase customGearBase, CustomCharacterGearInfo gearInfo) : base(customGearBase, gearInfo)
+        public ClothingGear(CustomGearBase customGearBase, CustomCharacterGearInfo gearInfo) : base(customGearBase, gearInfo)
         {
         }
 
@@ -250,19 +250,19 @@ namespace XLGearModifier.CustomGear
 
             switch (skaterIndex)
             {
-                case (int)Skater.EvanSmith:
+                case (int)XLMenuMod.Skater.EvanSmith:
                     Enum.TryParse(category, out EvanSmithGearCategory esCategory);
                     categoryIndex = (int)esCategory;
                     break;
-                case (int)Skater.TomAsta:
+                case (int)XLMenuMod.Skater.TomAsta:
                     Enum.TryParse(category, out TomAstaGearCategory taCategory);
                     categoryIndex = (int)taCategory;
                     break;
-                case (int)Skater.BrandonWestgate:
+                case (int)XLMenuMod.Skater.BrandonWestgate:
                     Enum.TryParse(category, out BrandonWestgateGearCategory bwCategory);
                     categoryIndex = (int)bwCategory;
                     break;
-                case (int)Skater.TiagoLemos:
+                case (int)XLMenuMod.Skater.TiagoLemos:
                     Enum.TryParse(category, out TiagoLemosGearCategory tlCategory);
                     categoryIndex = (int)tlCategory;
                     break;

--- a/XLGearModifier/CustomGear/CustomGearBase.cs
+++ b/XLGearModifier/CustomGear/CustomGearBase.cs
@@ -66,35 +66,35 @@ namespace XLGearModifier.CustomGear
         
         public int GetSkaterIndex()
         {
-            var skaterIndex = (int)Skater.MaleStandard;
+            var skaterIndex = (int)XLMenuMod.Skater.MaleStandard;
 
             var type = GetTypeName();
 
-            if (string.IsNullOrEmpty(type)) return (int)Skater.MaleStandard;
+            if (string.IsNullOrEmpty(type)) return (int)XLMenuMod.Skater.MaleStandard;
 
             if (type.StartsWith("m", StringComparison.InvariantCultureIgnoreCase))
             {
-                skaterIndex = (int)Skater.MaleStandard;
+                skaterIndex = (int)XLMenuMod.Skater.MaleStandard;
             }
             else if (type.StartsWith("f", StringComparison.InvariantCultureIgnoreCase))
             {
-                skaterIndex = (int)Skater.FemaleStandard;
+                skaterIndex = (int)XLMenuMod.Skater.FemaleStandard;
             }
             else if (type.StartsWith("es", StringComparison.InvariantCultureIgnoreCase))
             {
-                skaterIndex = (int)Skater.EvanSmith;
+                skaterIndex = (int)XLMenuMod.Skater.EvanSmith;
             }
             else if (type.StartsWith("ta", StringComparison.InvariantCultureIgnoreCase))
             {
-                skaterIndex = (int)Skater.TomAsta;
+                skaterIndex = (int)XLMenuMod.Skater.TomAsta;
             }
             else if (type.StartsWith("bw", StringComparison.InvariantCultureIgnoreCase))
             {
-                skaterIndex = (int)Skater.BrandonWestgate;
+                skaterIndex = (int)XLMenuMod.Skater.BrandonWestgate;
             }
             else if (type.StartsWith("tl", StringComparison.InvariantCultureIgnoreCase))
             {
-                skaterIndex = (int)Skater.TiagoLemos;
+                skaterIndex = (int)XLMenuMod.Skater.TiagoLemos;
             }
 
             return skaterIndex;

--- a/XLGearModifier/CustomGear/GearManager.cs
+++ b/XLGearModifier/CustomGear/GearManager.cs
@@ -87,7 +87,7 @@ namespace XLGearModifier.CustomGear
 			return materialController?.targets?.FirstOrDefault()?.renderer.material.shader;
         }
 		
-        public void AddBoardMesh(XLGMBoardGearMetadata metadata, CustomBoardGear customGearBase, GameObject asset)
+        public void AddBoardMesh(XLGMBoardGearMetadata metadata, BoardGear gearBase, GameObject asset)
 		{
 			CustomFolderInfo parent = null;
 
@@ -98,15 +98,15 @@ namespace XLGearModifier.CustomGear
 			if (metadata.BaseOnDefaultGear)
 			{
 				var officialTextures = Traverse.Create(GearDatabase.Instance).Field("gearListSource").GetValue<GearInfo[][][]>();
-				AddItem(customGearBase, officialTextures, parent.Children, ref parent);
+				AddItem(gearBase, officialTextures, parent.Children, ref parent);
 			}
 			else
 			{
-				AddItem(customGearBase, null, parent.Children, ref parent);
+				AddItem(gearBase, null, parent.Children, ref parent);
 			}
 		}
 
-		public void AddClothingMesh(XLGMClothingGearMetadata metadata, CustomClothingGear customGearBase, GameObject asset)
+		public void AddClothingMesh(XLGMClothingGearMetadata metadata, ClothingGear gearBase, GameObject asset)
 		{
 			CustomFolderInfo parent = null;
 
@@ -116,11 +116,11 @@ namespace XLGearModifier.CustomGear
 			if (metadata.BaseOnDefaultGear)
 			{
 				var officialTextures = Traverse.Create(GearDatabase.Instance).Field("gearListSource").GetValue<GearInfo[][][]>();
-				AddItem(customGearBase, officialTextures, parent.Children, ref parent);
+				AddItem(gearBase, officialTextures, parent.Children, ref parent);
 			}
 			else
 			{
-				AddItem(customGearBase, null, parent.Children, ref parent);
+				AddItem(gearBase, null, parent.Children, ref parent);
 			}
 		}
 
@@ -130,11 +130,11 @@ namespace XLGearModifier.CustomGear
 
 			foreach (var customGear in CustomGear)
             {
-                if (customGear is CustomSkater) continue;
+                if (customGear is Skater) continue;
 
 				CustomFolderInfo parent = null;
 
-                var cgi = customGear as CustomClothingGear;
+                var cgi = customGear as ClothingGear;
 
 				AddFolder<CustomGearFolderInfo>(customGear.Metadata.GetCategory(), string.Empty, cgi.ClothingMetadata.Skater == SkaterBase.Male ? CustomMeshes : CustomFemaleMeshes, ref parent);
 				AddFolder<CustomGearFolderInfo>(string.IsNullOrEmpty(customGear.Metadata.DisplayName) ? customGear.Prefab.name : customGear.Metadata.DisplayName, string.Empty, parent.Children, ref parent);
@@ -211,7 +211,7 @@ namespace XLGearModifier.CustomGear
 
 			if (customGearBase.Metadata.BasedOnDefaultGear())
 			{
-				if (customGearBase is CustomBoardGear)
+				if (customGearBase is BoardGear)
                 {
 					var baseTypes = categoryTextures.Where(x => x.type == customGearBase.Metadata.GetBaseType().ToLower()).Select(x => x as BoardGearInfo).ToList();
 					textures = textures.Concat(baseTypes).ToList();
@@ -293,11 +293,11 @@ namespace XLGearModifier.CustomGear
 			var child = destList.FirstOrDefault(x => x.GetName().Equals(baseTexture.name, StringComparison.InvariantCultureIgnoreCase));
 			if (child != null) return;
 
-			if (customGearBase is CustomBoardGear)
+			if (customGearBase is BoardGear)
 			{
 				CustomBoardGearInfo gearInfo = new CustomBoardGearInfo(baseTexture.name, customGearBase.GearInfo.type, isCustom, baseTexture.textureChanges, customGearBase.GearInfo.tags);
 				gearInfo.Info.Parent = parent;
-				gearInfo.Info.ParentObject = new CustomBoardGear(customGearBase, gearInfo);
+				gearInfo.Info.ParentObject = new BoardGear(customGearBase, gearInfo);
 				destList.Add(gearInfo.Info);
 
 				GearDatabase.Instance.boardGear.Add(gearInfo);
@@ -306,7 +306,7 @@ namespace XLGearModifier.CustomGear
 			{
 				CustomCharacterGearInfo gearInfo = new CustomCharacterGearInfo(baseTexture.name, customGearBase.GearInfo.type, isCustom, baseTexture.textureChanges, customGearBase.GearInfo.tags);
 				gearInfo.Info.Parent = parent;
-				gearInfo.Info.ParentObject = new CustomClothingGear(customGearBase, gearInfo);
+				gearInfo.Info.ParentObject = new ClothingGear(customGearBase, gearInfo);
 				destList.Add(gearInfo.Info);
 
 				GearDatabase.Instance.clothingGear.Add(gearInfo);
@@ -370,7 +370,7 @@ namespace XLGearModifier.CustomGear
 				{
 					characterGear.type = customGearBase.Metadata.Prefix.ToLower();
 					//child.ParentObject = customGear;
-					child.ParentObject = new CustomClothingGear(customGearBase, characterGear);
+					child.ParentObject = new ClothingGear(customGearBase, characterGear);
 				}
 				else if (child.GetParentObject() is CustomGearFolderInfo customGearFolder)
 				{

--- a/XLGearModifier/CustomGear/Skater.cs
+++ b/XLGearModifier/CustomGear/Skater.cs
@@ -9,11 +9,11 @@ using XLGearModifier.Unity;
 
 namespace XLGearModifier.CustomGear
 {
-    public class CustomSkater : CustomGearBase
+    public class Skater : CustomGearBase
     {
         public XLGMSkaterMetadata SkaterMetadata => Metadata as XLGMSkaterMetadata;
 
-        public CustomSkater(XLGMSkaterMetadata metadata, GameObject prefab) 
+        public Skater(XLGMSkaterMetadata metadata, GameObject prefab) 
             : base(metadata, prefab)
         {
         }

--- a/XLGearModifier/Patches/ClothingGearObjectPatch.cs
+++ b/XLGearModifier/Patches/ClothingGearObjectPatch.cs
@@ -73,7 +73,7 @@ namespace XLGearModifier.Patches
 			var customGearInfo = clothingGear.gearInfo as CustomCharacterGearInfo;
 			if (customGearInfo == null) return false;
 
-			if (customGearInfo.Info.GetParentObject() is CustomClothingGear customGear)
+			if (customGearInfo.Info.GetParentObject() is ClothingGear customGear)
 			{
 				if (!isType)
 				{
@@ -94,7 +94,7 @@ namespace XLGearModifier.Patches
 
 			bool isLayerable = false;
 
-			if (customGearInfo.Info.GetParentObject() is CustomClothingGear customGear)
+			if (customGearInfo.Info.GetParentObject() is ClothingGear customGear)
 			{
 				isLayerable = customGear.ClothingMetadata.IsLayerable && customGear.Metadata.GetCategory().StartsWith(clothingGearCategory.ToString());
 			}

--- a/XLGearModifier/Patches/GearSelectionControllerPatch.cs
+++ b/XLGearModifier/Patches/GearSelectionControllerPatch.cs
@@ -13,6 +13,7 @@ using XLMenuMod.Utilities;
 using XLMenuMod.Utilities.Gear;
 using XLMenuMod.Utilities.Interfaces;
 using XLMenuMod.Utilities.UserInterface;
+using Skater = XLMenuMod.Skater;
 
 namespace XLGearModifier.Patches
 {

--- a/XLGearModifier/UserInterfaceHelper.cs
+++ b/XLGearModifier/UserInterfaceHelper.cs
@@ -58,7 +58,7 @@ namespace XLGearModifier
 				var spriteIndex = GearModifierUISpriteSheet.spriteCharacterTable[GetSpriteIndex(template)].glyphIndex;
 				var sprite = GearModifierUISpriteSheetSprites.FirstOrDefault(x => x.name == "GearModifierUISpriteSheet_" + spriteIndex);
 
-				var mesh = GearManager.Instance.CustomGear.FirstOrDefault(x => x.GearInfo != null && x.GearInfo.type == clothingGear.type) as CustomClothingGear;
+				var mesh = GearManager.Instance.CustomGear.FirstOrDefault(x => x.GearInfo != null && x.GearInfo.type == clothingGear.type) as ClothingGear;
 
 				var creatorName = mesh?.ClothingMetadata?.CreatorName ?? "N/A";
 

--- a/XLGearModifier/XLGearModifier.csproj
+++ b/XLGearModifier/XLGearModifier.csproj
@@ -118,10 +118,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssetBundleHelper.cs" />
-    <Compile Include="CustomGear\CustomBoardGear.cs" />
-    <Compile Include="CustomGear\CustomClothingGear.cs" />
+    <Compile Include="CustomGear\BoardGear.cs" />
+    <Compile Include="CustomGear\ClothingGear.cs" />
     <Compile Include="CustomGear\CustomGearBase.cs" />
-    <Compile Include="CustomGear\CustomSkater.cs" />
+    <Compile Include="CustomGear\Skater.cs" />
     <Compile Include="CustomGear\GearManager.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="Patches\CharacterCustomizerPatch.cs" />


### PR DESCRIPTION
Since we're planning on a new direction as far as XLMenuMod integration, we wanted to go ahead and sort all of the meshes and textures alphabetically so those views would seem a little less chaotic.

- Renamed `CustomClothingGear` to `ClothingGear`.
- Renamed `CustomSkater` to `Skater`.
- Renamed `CustomBoardGear` to `BoardGear`.
- Moved `GearManager` into `CustomGear` folder/namespace.
- Updated `GearManager` to inherit from XLMenuMod's `CustomGearManager`, which provides many methods that could be useful to us (not sure why this inheritance wasn't already in place?).
  - Override `SortList` method to ensure our CurrentSort is always set to `Name_ASC`.
- Updated `GearSelectionController.ListView_OnItemSelectedEventPatch` to ensure that the list gets sorted every time a folder is selected.

This closes #66.