### PR TITLE
Fixing Wrong Icons on What's Equipped Menu

### DIFF
--- a/XLGearModifier/UserInterfaceHelper.cs
+++ b/XLGearModifier/UserInterfaceHelper.cs
@@ -67,38 +67,33 @@ namespace XLGearModifier
 		}
 
 		private int GetSpriteIndex(CharacterGearTemplate template)
-		{
-			int spriteIndex = 0;
+        {
+			if (GearManager.Instance.CustomGear.FirstOrDefault(x => x.Metadata.Prefix.ToLower() == template.id) is ClothingGear customGear)
+            {
+                var spriteName = customGear.Metadata.GetSprite();
+                return GearModifierUISpriteSheet.GetSpriteIndexFromName(spriteName);
+            }
 
 			switch (template.category)
 			{
 				case ClothingGearCategory.Shoes:
-					
-					spriteIndex = GearModifierUISpriteSheet.GetSpriteIndexFromName("Shoes");
-					break;
-				case ClothingGearCategory.Hoodie:
+                    return GearModifierUISpriteSheet.GetSpriteIndexFromName("Shoes");
+                case ClothingGearCategory.Hoodie:
 				case ClothingGearCategory.LongSleeve:
 				case ClothingGearCategory.Shirt:
 				case ClothingGearCategory.TankTop:
-					spriteIndex = GearModifierUISpriteSheet.GetSpriteIndexFromName("Top");
-					break;
-				case ClothingGearCategory.Pants:
+					return GearModifierUISpriteSheet.GetSpriteIndexFromName("Top");
+                case ClothingGearCategory.Pants:
 				case ClothingGearCategory.PantsRolledUp:
 				case ClothingGearCategory.Shorts:
-					spriteIndex = GearModifierUISpriteSheet.GetSpriteIndexFromName("Bottom");
-					break;
-				case ClothingGearCategory.Socks:
-					spriteIndex = GearModifierUISpriteSheet.GetSpriteIndexFromName("Socks");
-					break;
-				case ClothingGearCategory.Hat:
-					spriteIndex = GearModifierUISpriteSheet.GetSpriteIndexFromName("Headwear");
-					break;
-				default:
-					spriteIndex = GearModifierUISpriteSheet.GetSpriteIndexFromName("Other");
-					break;
-			}
-
-			return spriteIndex;
-		}
+					return GearModifierUISpriteSheet.GetSpriteIndexFromName("Bottom");
+                case ClothingGearCategory.Socks:
+					return GearModifierUISpriteSheet.GetSpriteIndexFromName("Socks");
+                case ClothingGearCategory.Hat:
+					return GearModifierUISpriteSheet.GetSpriteIndexFromName("Headwear");
+                default:
+					return GearModifierUISpriteSheet.GetSpriteIndexFromName("Other");
+            }
+        }
 	}
 }


### PR DESCRIPTION
- Previously, we were trying to base the icon purely off of the category of the item, which isn't quite the full solution.
- Now, if the object is a custom gear object we loaded, we will look at the `Sprite` field defined on the `XLGMMetadata` that it is using.  If it is not a mesh we loaded, _then_ we will try to figure out the appropriate icon to display based on category.
- This will close #32.