### PR TITLE
Fixing Custom Skaters Menu

### DIFF
--- a/XLGearModifier/Patches/GearSelectionControllerPatch.cs
+++ b/XLGearModifier/Patches/GearSelectionControllerPatch.cs
@@ -56,6 +56,7 @@ namespace XLGearModifier.Patches
 				if (index.depth < 2) return;
 
                 var sourceList = GetSourceList(index);
+                if (!sourceList.Any()) return;
 
                 if (index.depth == 2)
 				{


### PR DESCRIPTION
- Fixing a small issue that was introduced with #117 that broke the gear menu for custom skaters with Allow Clothing turned off.