### PR TITLE
Updating "Socks" Category Items to Not Block

### DIFF
--- a/XLGearModifier/Patches/ClothingGearObjectPatch.cs
+++ b/XLGearModifier/Patches/ClothingGearObjectPatch.cs
@@ -42,6 +42,13 @@ namespace XLGearModifier.Patches
                     return false;
                 }
 
+                // If either item is "Socks" in our metadata script, it shouldn't block any other items.
+                if (__instance.IsLayerableCategory(Unity.ClothingGearCategory.Socks) || otherCGO.IsLayerableCategory(Unity.ClothingGearCategory.Socks))
+                {
+                    __result = false;
+                    return false;
+                }
+
                 return true;
 			}
 		}


### PR DESCRIPTION
- Updating layerable logic for layerable "socks" items to not block any other items.
  - Behave very similarly to "Other" and "Facial Hair" items now.
- This will close #181.