### PR TITLE
L3 To Show/Hide What's Equipped

### DIFF
--- a/XLGearModifier/Patches/GearSelectionControllerPatch.cs
+++ b/XLGearModifier/Patches/GearSelectionControllerPatch.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Rewired;
 using SkaterXL.Data;
 using System;
 using System.Collections.Generic;
@@ -10,11 +11,9 @@ using XLGearModifier.CustomGear;
 using XLGearModifier.Texturing;
 using XLGearModifier.Unity;
 using XLMenuMod;
-using XLMenuMod.Utilities;
 using XLMenuMod.Utilities.Gear;
 using XLMenuMod.Utilities.Interfaces;
 using XLMenuMod.Utilities.UserInterface;
-using Skater = XLMenuMod.Skater;
 
 namespace XLGearModifier.Patches
 {
@@ -504,6 +503,20 @@ namespace XLGearModifier.Patches
 
 				return false;
 			}
+
+			/// <summary>
+			/// After update runs, see if L3 was clicked, if so toggle whether or not the what's equipped menu is active.
+			/// </summary>
+            static void Postfix(GearSelectionController __instance)
+            {
+                var player = Traverse.Create(__instance).Field("player").GetValue<Player>();
+                
+                if (!player.GetButtonDown("Left Stick Button")) return;
+                if (UserInterfaceHelper.Instance.whatsEquippedUI == null) return;
+                
+                UISounds.Instance?.PlayOneShotSelectionChange();
+                UserInterfaceHelper.Instance.whatsEquippedUI.SetActive(!UserInterfaceHelper.Instance.whatsEquippedUI.activeInHierarchy);
+            }
 		}
 
 		public static bool IsOnXLGMTab(IndexPath index)

--- a/XLGearModifier/XLGearModifier.csproj
+++ b/XLGearModifier/XLGearModifier.csproj
@@ -150,6 +150,7 @@
     <EmbeddedResource Include="Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="app.config" />
     <EmbeddedResource Include="Assets\default-empty-textures" />


### PR DESCRIPTION
- Updating GearSelectionController such that pressing L3 will toggle the visibility of the What's Equipped menu.