### PR TITLE
Preventing Exceptions and Reworking LoadLastPlayer Calls

### DIFF
--- a/XLGearModifier/AssetBundleHelper.cs
+++ b/XLGearModifier/AssetBundleHelper.cs
@@ -29,7 +29,7 @@ namespace XLGearModifier
             var test = GearModifierTab.CustomMeshes;
 
             await PlayerController.Instance.StartCoroutine(LoadBuiltInBundles());
-            await PlayerController.Instance.StartCoroutine(LoadUserBundles());
+            //await PlayerController.Instance.StartCoroutine(LoadUserBundles());
         }
 
         private IEnumerator LoadBuiltInBundles()
@@ -37,14 +37,14 @@ namespace XLGearModifier
             var assembly = Assembly.GetExecutingAssembly();
             var assetBundles = assembly.GetManifestResourceNames();
 
-            MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loading built in bundles...", 1f);
+            //MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loading built in bundles...", 1f);
 
             foreach (var assetBundle in assetBundles)
             {
                 yield return LoadBuiltInBundle(assembly, assetBundle);
             }
 
-            MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loaded built in bundles.", 3f);
+            //MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loaded built in bundles.", 3f);
 
             PlayerController.Instance.characterCustomizer.LoadLastPlayer();
             GearDatabase.Instance.FetchCustomGear();
@@ -52,6 +52,8 @@ namespace XLGearModifier
 
 		private IEnumerator LoadBuiltInBundle(Assembly assembly, string bundleName)
 		{
+            if (bundleName == "XLGearModifier.Strings.resources") yield break;
+
             Debug.Log("XLGearModifier: Loading " + bundleName);
 
             var bytes = ExtractResource(assembly, bundleName);

--- a/XLGearModifier/AssetBundleHelper.cs
+++ b/XLGearModifier/AssetBundleHelper.cs
@@ -30,6 +30,9 @@ namespace XLGearModifier
 
             await PlayerController.Instance.StartCoroutine(LoadBuiltInBundles());
             await PlayerController.Instance.StartCoroutine(LoadUserBundles());
+
+            await PlayerController.Instance.characterCustomizer.LoadLastPlayer();
+            GearDatabase.Instance.FetchCustomGear();
         }
 
         private IEnumerator LoadBuiltInBundles()
@@ -45,9 +48,6 @@ namespace XLGearModifier
             }
 
             MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loaded built in bundles.", 3f);
-
-            PlayerController.Instance.characterCustomizer.LoadLastPlayer();
-            GearDatabase.Instance.FetchCustomGear();
         }
 
 		private IEnumerator LoadBuiltInBundle(Assembly assembly, string bundleName)
@@ -253,9 +253,6 @@ namespace XLGearModifier
 
             if (assetBundleFiles.Any())
                 MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loaded {assetBundleFiles.Count()} user bundles.", 3f);
-
-            PlayerController.Instance.characterCustomizer.LoadLastPlayer();
-            GearDatabase.Instance.FetchCustomGear();
         }
     }
 }

--- a/XLGearModifier/AssetBundleHelper.cs
+++ b/XLGearModifier/AssetBundleHelper.cs
@@ -29,7 +29,7 @@ namespace XLGearModifier
             var test = GearModifierTab.CustomMeshes;
 
             await PlayerController.Instance.StartCoroutine(LoadBuiltInBundles());
-            //await PlayerController.Instance.StartCoroutine(LoadUserBundles());
+            await PlayerController.Instance.StartCoroutine(LoadUserBundles());
         }
 
         private IEnumerator LoadBuiltInBundles()
@@ -37,14 +37,14 @@ namespace XLGearModifier
             var assembly = Assembly.GetExecutingAssembly();
             var assetBundles = assembly.GetManifestResourceNames();
 
-            //MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loading built in bundles...", 1f);
+            MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loading built in bundles...", 1f);
 
             foreach (var assetBundle in assetBundles)
             {
                 yield return LoadBuiltInBundle(assembly, assetBundle);
             }
 
-            //MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loaded built in bundles.", 3f);
+            MessageSystem.QueueMessage(MessageDisplayData.Type.Info, $"Loaded built in bundles.", 3f);
 
             PlayerController.Instance.characterCustomizer.LoadLastPlayer();
             GearDatabase.Instance.FetchCustomGear();

--- a/XLGearModifier/Patches/CharacterCustomizerPatch.cs
+++ b/XLGearModifier/Patches/CharacterCustomizerPatch.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using HarmonyLib;
+using SkaterXL.Data;
 using System.Collections.Generic;
 using System.Linq;
-using HarmonyLib;
-using SkaterXL.Data;
 using XLGearModifier.CustomGear;
 using XLGearModifier.Texturing;
 using XLMenuMod.Utilities;
@@ -13,6 +12,18 @@ namespace XLGearModifier.Patches
 {
     public class CharacterCustomizerPatch
 	{
+        [HarmonyPatch(typeof(CharacterCustomizer), "UpdateMasksFrom")]
+        static class UpdateMasksFromPatch
+        {
+            /// <summary>
+            /// Filters out any gear where template is null, which was an issue when trying to load the character. 
+            /// </summary>
+            static void Prefix(CharacterCustomizer __instance, ref IEnumerable<ClothingGearObjet> gearForMask)
+            {
+                gearForMask = gearForMask?.Where(x => x?.template != null);
+            }
+        }
+
 		[HarmonyPatch(typeof(CharacterCustomizer), nameof(CharacterCustomizer.HasEquipped), typeof(ICharacterCustomizationItem))]
 		static class HasEquippedPatch
 		{

--- a/XLGearModifier/XLGearModifier.csproj
+++ b/XLGearModifier/XLGearModifier.csproj
@@ -150,6 +150,7 @@
     <EmbeddedResource Include="Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="app.config" />
     <EmbeddedResource Include="Assets\default-empty-textures" />


### PR DESCRIPTION
- Instead of calling `LoadLastPlayer` and `FetchCustomGear` at the end of `LoadBuiltInBundles` AND `LoadUserBundles`, simply call it a single time at the end of `LoadBundles`.
    - Also awaiting `LoadLastPlayer` now, which could potentially help with people's loading issues?
- Preventing mod trying to load string resources as an asset bundle, causing the `Failed to decompress data for the AssetBundle 'Memory'.` error.
- Preventing mod from trying to `UpdateMasksFrom` with gear with null templates.  Was throwing exception(s) on startup depending on the gear the user had equipped.  May be moot now with other changes but still a valuable filter, as template should never be null.